### PR TITLE
Adding shader debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Overrides that can be used to alter the behaviour of the experience.
 | uniforms                                 | `object`   | `{}`            | Shared values between all instances that can be updated at any given moment. By default this feature is used to render all the instances with the same `uProjectionMatrix`, `uModelMatrix` and `uViewMatrix`. It's also useful for moving everything around with the same progress value; `uProgress`. |
 | onSetup(gl)                              | `function` | `undefined`     | A setup hook that is called before first render which can be used for gl context changes. |
 | onRender(renderer)                       | `function` | `undefined`     | A render hook that is invoked after every rendered frame. Use this to update `renderer.uniforms`. |
+| debug                                    | `boolean`  | `false`         | Whether or not the console should log shader compilation warnings. |
+
 
 ### .resize()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ interface RendererProps {
   context?: object;
   contextType?: string;
   settings?: object;
+  debug?: boolean;
 }
 
 const positionMap = ['x', 'y', 'z'];
@@ -285,6 +286,7 @@ class Renderer {
     [key: string]: UniformProps;
   };
   public shouldRender: boolean;
+  public debug: boolean;
 
   /**
    * Create a renderer.
@@ -295,6 +297,7 @@ class Renderer {
       context = {},
       contextType = 'experimental-webgl',
       settings = {},
+      debug = false,
     } = props || {};
 
     // Get context with optional parameters
@@ -323,7 +326,8 @@ class Renderer {
       devicePixelRatio: 1,
       clearColor: [1, 1, 1, 1],
       position: { x: 0, y: 0, z: 2 },
-      clip: [0.001, 100]
+      clip: [0.001, 100],
+      debug,
     });
 
     // Assign optional parameters
@@ -464,6 +468,24 @@ class Renderer {
 
     const instance = new Instance(settings);
     this.instances.set(key, instance);
+
+    if (this.debug) {
+      // debug vertex shader
+      const vertexDebug = this.gl.createShader(this.gl.VERTEX_SHADER);
+      this.gl.shaderSource(vertexDebug, settings.vertex);
+      this.gl.compileShader(vertexDebug);
+      if (!this.gl.getShaderParameter(vertexDebug, this.gl.COMPILE_STATUS)) {
+        console.error(this.gl.getShaderInfoLog(vertexDebug));
+      }
+
+      // debug fragment shader
+      const fragmentDebug = this.gl.createShader(this.gl.FRAGMENT_SHADER);
+      this.gl.shaderSource(fragmentDebug, settings.fragment);
+      this.gl.compileShader(fragmentDebug);
+      if (!this.gl.getShaderParameter(fragmentDebug, this.gl.COMPILE_STATUS)) {
+        console.error(this.gl.getShaderInfoLog(fragmentDebug));
+      }
+    }
 
     return instance;
   }


### PR DESCRIPTION
Hey again! I'm using this library some more and ran into a shader compilation error that took a while to track down:

<img width="459" alt="Screen Shot 2019-09-27 at 12 36 52 PM" src="https://user-images.githubusercontent.com/5344587/65785938-8bf98000-e123-11e9-8e0a-b8d003d6260d.png">

So I added a `debug` option to log shader compilation errors:

<img width="460" alt="Screen Shot 2019-09-27 at 12 37 04 PM" src="https://user-images.githubusercontent.com/5344587/65785995-b0edf300-e123-11e9-9dcf-6a275415bed5.png">

The only new property of the Renderer is this:

```
const renderer = new Phenomenon({
    debug: true
})
```

`debug` is false by default, so I added some documentation for this feature as well. Thanks for the excellent work and let me know if there's anything I should change!